### PR TITLE
run debuild with --no-lintian

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,7 +32,7 @@ sudo mk-build-deps -i -r
 
 + Build package
 ```
-debuild -b -uc -us
+debuild --no-lintian -b -uc -us
 ```
 
 + Install package


### PR DESCRIPTION
Otherwise there are too many lintian errors on newer distros like
Ubuntu Xenial 16.04. Of course it is not a clean solution but it
works and until somebody want to make this upstream package it is
good enough.
